### PR TITLE
meta: extend license year range to 2021

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2020 Swellaby
+Copyright (c) 2018-2021 Swellaby
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Closes #34 

Going to go ahead and bump this since we'll likely need to release a new version in the relatively near future